### PR TITLE
Assistant checkpoint: Filter pizza grants API to hide personal info f…

### DIFF
--- a/main.py
+++ b/main.py
@@ -2261,7 +2261,31 @@ def get_club_pizza_grants(club_id):
         all_submissions = airtable_service.get_pizza_grant_submissions()
         # Filter submissions for this club only
         club_submissions = [sub for sub in all_submissions if sub.get('club_name') == club.name]
-        return jsonify({'submissions': club_submissions})
+        
+        # Filter response based on user role
+        if is_leader:
+            # Leaders can see all fields for their club
+            filtered_submissions = club_submissions
+        else:
+            # Regular members can only see safe, non-personal fields
+            filtered_submissions = []
+            for sub in club_submissions:
+                filtered_sub = {
+                    'id': sub.get('id'),
+                    'project_name': sub.get('project_name'),
+                    'description': sub.get('description'),
+                    'playable_url': sub.get('playable_url'),
+                    'code_url': sub.get('code_url'),
+                    'hours': sub.get('hours'),
+                    'grant_amount': sub.get('grant_amount'),
+                    'status': sub.get('status'),
+                    'created_time': sub.get('created_time'),
+                    'github_username': sub.get('github_username'),
+                    'screenshot_url': sub.get('screenshot_url')
+                }
+                filtered_submissions.append(filtered_sub)
+        
+        return jsonify({'submissions': filtered_submissions})
     except Exception as e:
         logger.error(f"Error fetching club pizza grant submissions: {str(e)}")
         return jsonify({'error': 'Failed to fetch submissions from Airtable'}), 500


### PR DESCRIPTION
…rom members

Assistant generated file changes:
- main.py: Filter pizza grants API response to only include safe fields

---

User prompt:

not a huge thing but the https://dashboard.hackclub.com/api/clubs/39/pizza-grants gives the whole object when it could really be just sending name, desc,

what it sends rn:

{
  "submissions": [
    {
      "address_1": "15 falls road ",
      "address_2": "",
      "city": "Shelburne",
      "club_name": "105 OR 1=1's Club",
      "code_url": "https://github.com/hackclub/site",
      "country": "USA",
      "created_time": "2025-06-10T20:06:18.000Z",
      "description": "test\n",
      "doing_well": "testing for bugs",
      "email": "no@hack.af",
      "first_name": "No",
      "github_username": "105 OR 1=1",
      "grant_amount": "$0",
      "hours": "0.0",
      "id": "recic3WhX4b5kpbBe",
      "improve": "bugs",
      "last_name": "Bugtester",
      "leader_email": "no@hack.af",
      "playable_url": "https://github.com/hackclub/site",
      "project_name": "Fakee",
      "screenshot_url": "",
      "state": "VT",
      "status": "Flagged",
      "zip": "05482"
    }
  ]
}

so club members can see unessary personal info when seeing the pizza grants or whatever

Everyone can see project grants #30
Open
@NeonGamerBot-QK
Description
NeonGamerBot-QK
opened 23 minutes ago
idk if this is intentional but due to #26 this is leaking peoples address :3 not a huge vuln rn since nobody is on it atm and def nobody has submited project grants

Resources arent checked to be real links. #28
Open
@NeonGamerBot-QK
Description
NeonGamerBot-QK
opened 31 minutes ago
While this can be useful it should check for https:// links

No server side validation on hackatime projects #29

Replit-Commit-Author: Assistant
Replit-Commit-Session-Id: 13c8ce3c-dbb9-4200-9962-c7bec5371a1b